### PR TITLE
Fix for virtualenv installs

### DIFF
--- a/rest_framework_cache/__init__.py
+++ b/rest_framework_cache/__init__.py
@@ -1,5 +1,7 @@
+import pkg_resources
 __author__ = 'Ervilis Souza'
 __email__ = 'ervilisviana@gmail.com'
 __version__ = '0.1.1'
 
+pkg_resources.declare_namespace(__name__)
 default_app_config = 'rest_framework_cache.apps.RestFrameworkCacheConfig'

--- a/rest_framework_cache/__init__.py
+++ b/rest_framework_cache/__init__.py
@@ -1,9 +1,5 @@
-import pkg_resources
-
-
 __author__ = 'Ervilis Souza'
 __email__ = 'ervilisviana@gmail.com'
-__version__ = '0.1'
+__version__ = '0.1.1'
 
-
-pkg_resources.declare_namespace(__name__)
+default_app_config = 'rest_framework_cache.apps.RestFrameworkCacheConfig'

--- a/rest_framework_cache/apps.py
+++ b/rest_framework_cache/apps.py
@@ -1,0 +1,5 @@
+from django.apps import AppConfig
+
+class RestFrameworkCacheConfig(AppConfig):
+    name = 'rest_framework_cache'
+    verbose_name = "REST Framework Cache"


### PR DESCRIPTION
I was getting an error similar to #5, and found that because virtualenv in Linux installs a copy of the app at `[virtualenv]/local/lib/python2.7/site-packages/rest_framework_cache` and another copy at  `[virtualenv]/lib/python2.7/site-packages/rest_framework_cache`, Django complained that AppConfig was needed.
Following the instructions for application authors on the [django documentation](https://docs.djangoproject.com/en/1.10/ref/applications/#for-application-authors) I fixed the problem.