### PR TITLE
install fix: __init__.py not installs by pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     keywords="rest_framework_cache",
     url=github_url,
     packages=['rest_framework_cache', 'tests'],
-    namespace_packages=['rest_framework_cache'],
     package_dir={'rest_framework_cache': 'rest_framework_cache'},
     download_url="{}/tarball/master".format(github_url),
     tests_require=["Django", "djangorestframework", "mock"],


### PR DESCRIPTION
Currently pip looses __init__.py in rest_framework_cache folder